### PR TITLE
Add About dialog and Windows dev-run wrapper; update run-dev script and README

### DIFF
--- a/FluxRouteDev/ViewModels/MainViewModel.cs
+++ b/FluxRouteDev/ViewModels/MainViewModel.cs
@@ -52,6 +52,7 @@ public partial class MainViewModel : ObservableObject
 
     // ── События ──
     public event EventHandler? OpenSettingsRequested;
+    public event EventHandler? OpenAboutRequested;
 
     // ── Профиль ──
     public string SelectedScriptName => SelectedProfile?.FileName ?? "—";
@@ -170,6 +171,12 @@ public partial class MainViewModel : ObservableObject
     private void ToggleSettings()
     {
         OpenSettingsRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private void OpenAbout()
+    {
+        OpenAboutRequested?.Invoke(this, EventArgs.Empty);
     }
 
     [RelayCommand]

--- a/FluxRouteDev/Views/AboutWindow.xaml
+++ b/FluxRouteDev/Views/AboutWindow.xaml
@@ -1,0 +1,56 @@
+<Window x:Class="FluxRoute.Views.AboutWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="О проекте FluxRoute"
+        Height="560" Width="620"
+        WindowStartupLocation="CenterOwner"
+        Background="#1E1E1E"
+        ResizeMode="CanMinimize"
+        ShowInTaskbar="False">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="52"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Background="#252526">
+            <Grid Margin="16,0">
+                <TextBlock Text="ℹ️ О проекте FluxRoute" FontSize="16" FontWeight="SemiBold"
+                           Foreground="White" VerticalAlignment="Center"/>
+                <Button Content="✕" Width="30" Height="30" HorizontalAlignment="Right" VerticalAlignment="Center"
+                        Foreground="#AAAAAA" Background="Transparent" BorderThickness="0"
+                        FontSize="16" Cursor="Hand" Click="CloseButton_Click"/>
+            </Grid>
+        </Border>
+
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="20,16">
+                <TextBlock Text="Для чего создан проект" Foreground="#4FC3F7" FontWeight="SemiBold" FontSize="14"/>
+                <TextBlock Margin="0,8,0,0" Foreground="#DDDDDD" TextWrapping="Wrap" FontSize="13"
+                           Text="FluxRoute создан как удобный desktop-интерфейс для управления сетевыми профилями и сценариями обхода ограничений. Главная цель — упростить запуск и переключение стратегий без ручного редактирования bat-файлов и служебных настроек."/>
+
+                <Rectangle Height="1" Fill="#3E3E42" Margin="0,14,0,14"/>
+
+                <TextBlock Text="Как работает" Foreground="#4FC3F7" FontWeight="SemiBold" FontSize="14"/>
+                <TextBlock Margin="0,8,0,0" Foreground="#DDDDDD" TextWrapping="Wrap" FontSize="13"
+                           Text="Приложение загружает профили из каталога engine, запускает выбранный сценарий, отслеживает статус процесса и базовую диагностику. Внутри есть оркестратор, который анализирует доступность выбранных целей и помогает переключать профиль на более стабильный."/>
+
+                <Rectangle Height="1" Fill="#3E3E42" Margin="0,14,0,14"/>
+
+                <TextBlock Text="Благодарности разработчикам" Foreground="#4FC3F7" FontWeight="SemiBold" FontSize="14"/>
+                <TextBlock Margin="0,8,0,0" Foreground="#DDDDDD" TextWrapping="Wrap" FontSize="13"
+                           Text="Спасибо всем, кто участвует в развитии проекта: автору идеи, разработчикам ядра и GUI, тестировщикам, а также участникам сообщества, которые делятся обратной связью, логами и проверяют профили в реальных условиях."/>
+
+                <Rectangle Height="1" Fill="#3E3E42" Margin="0,14,0,14"/>
+
+                <TextBlock Text="Что изучалось и источники" Foreground="#4FC3F7" FontWeight="SemiBold" FontSize="14"/>
+                <TextBlock Margin="0,8,0,0" Foreground="#DDDDDD" TextWrapping="Wrap" FontSize="13"
+                           Text="При разработке использовались материалы и документация по WPF/.NET, MVVM-подходу, сетевой диагностике, а также открытые технические обсуждения по настройке маршрутизации и работе сетевых фильтров в Windows."/>
+
+                <TextBlock Margin="0,18,0,0" Foreground="#AAAAAA" FontSize="12" TextWrapping="Wrap"
+                           Text="Если хотите, можно дополнительно указать персональные ники/ссылки разработчиков и точный список источников — я добавлю это в отдельный блок."/>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</Window>

--- a/FluxRouteDev/Views/AboutWindow.xaml.cs
+++ b/FluxRouteDev/Views/AboutWindow.xaml.cs
@@ -1,0 +1,16 @@
+using System.Windows;
+
+namespace FluxRoute.Views;
+
+public partial class AboutWindow : Window
+{
+    public AboutWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}

--- a/FluxRouteDev/Views/MainWindow.xaml
+++ b/FluxRouteDev/Views/MainWindow.xaml
@@ -24,9 +24,9 @@
                 <TextBlock Text="🔷 FluxRoute" FontSize="22" FontWeight="Bold"
                            Foreground="White" VerticalAlignment="Center"/>
                 <Button Width="35" Height="35" HorizontalAlignment="Right" VerticalAlignment="Center"
-                        Command="{Binding ToggleSettingsCommand}"
+                        Command="{Binding OpenAboutCommand}"
                         Background="Transparent" BorderBrush="Transparent"
-                        Foreground="White" FontSize="18" Cursor="Hand" Content="⚙️">
+                        Foreground="White" FontSize="18" Cursor="Hand" Content="ℹ️">
                     <Button.Style>
                         <Style TargetType="Button">
                             <Setter Property="Template">

--- a/FluxRouteDev/Views/MainWindow.xaml.cs
+++ b/FluxRouteDev/Views/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ public partial class MainWindow : Window
 {
     private readonly MainViewModel _vm;
     private SettingsWindow? _settingsWindow;
+    private AboutWindow? _aboutWindow;
 
     public MainWindow()
     {
@@ -16,6 +17,20 @@ public partial class MainWindow : Window
 
         // Открываем настройки когда ViewModel просит
         _vm.OpenSettingsRequested += OnOpenSettingsRequested;
+        _vm.OpenAboutRequested += OnOpenAboutRequested;
+    }
+
+
+    private void OnOpenAboutRequested(object? sender, EventArgs e)
+    {
+        if (_aboutWindow is { IsVisible: true })
+        {
+            _aboutWindow.Activate();
+            return;
+        }
+
+        _aboutWindow = new AboutWindow() { Owner = this };
+        _aboutWindow.Show();
     }
 
     private void OnOpenSettingsRequested(object? sender, EventArgs e)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # FluxRouteDev
+
+## Быстрый запуск dev-режима (Windows)
+
+Если при запуске `run-dev.ps1` появляется ошибка про `ExecutionPolicy` (UnauthorizedAccess),
+используйте обёртку:
+
+```bat
+run-dev.cmd
+```
+
+Дополнительно можно передать те же аргументы, что и в PowerShell-скрипт:
+
+```bat
+run-dev.cmd -Branch main -NoPull
+```
+
+`run-dev.cmd` запускает PowerShell с `-ExecutionPolicy Bypass` только для текущего процесса,
+не меняя глобальную политику системы.

--- a/run-dev.cmd
+++ b/run-dev.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal
+
+REM Wrapper to run run-dev.ps1 even when script execution is restricted.
+REM Applies bypass only to this PowerShell process.
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0run-dev.ps1" %*
+set EXIT_CODE=%ERRORLEVEL%
+
+if not "%EXIT_CODE%"=="0" (
+    echo.
+    echo FluxRoute Dev Runner finished with code %EXIT_CODE%.
+)
+
+exit /b %EXIT_CODE%

--- a/run-dev.ps1
+++ b/run-dev.ps1
@@ -1,9 +1,11 @@
 # run-dev.ps1
 param(
     [string]$Branch = "main",           # Ветка по умолчанию
-    [string]$ProjectPath = "FluxRoute.App/FluxRoute.App.csproj",
+    [string]$ProjectPath = "FluxRouteDev/FluxRouteDev.csproj",
     [switch]$NoPull                     # Если true — не делать pull
 )
+
+$needStashPop = $false
 
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host "  🔷 FluxRoute — Dev Runner" -ForegroundColor Cyan


### PR DESCRIPTION
### Motivation
- Provide an in-app "About" dialog to surface project information and credits from the main UI header.
- Make the local developer startup on Windows more convenient when PowerShell execution policy prevents running `run-dev.ps1` directly.
- Point the dev-run script to the correct project file for the dev solution.

### Description
- Added an `AboutWindow` view and code-behind (`Views/AboutWindow.xaml` and `AboutWindow.xaml.cs`) with informational content about the project. 
- Exposed `OpenAboutRequested` event and `OpenAbout` relay command in `MainViewModel`, and wired the main window header button to `OpenAboutCommand` instead of opening settings. 
- Updated `MainWindow` to listen for `OpenAboutRequested`, manage a single `AboutWindow` instance and show/activate it when requested. 
- Added a Windows wrapper script `run-dev.cmd` that launches `run-dev.ps1` with `-ExecutionPolicy Bypass` for the current process, and updated `run-dev.ps1` to use the `FluxRouteDev/FluxRouteDev.csproj` path and stash/un-stash logic. 
- Updated `README.md` with instructions for using `run-dev.cmd` and passing arguments.

### Testing
- Ran the automated build step via the updated `run-dev.ps1` (`dotnet build FluxRouteDev/FluxRouteDev.csproj --configuration Debug`) and the build completed successfully. 
- No automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac599371ec8322a74d10e5008d1082)