### PR TITLE
fix: remove duplicate rows in English README comparison table

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -125,8 +125,6 @@ FluxRoute is the **only** GUI with a full-featured AI subsystem:
 | 🧠 AI Orchestrator (Thompson Sampling) | ✅ | ❌ | ❌ | ❌ | ❌ |
 | 🧬 Genetic Strategy Evolution | ✅ | ❌ | ❌ | ❌ | ❌ |
 | 🔄 Orchestrator (auto-scanning) | ✅ | ❌ | ❌ | ✅ | ❌ |
-| 🔄 Orchestrator (auto-scanning) | ✅ | ❌ | ❌ | ✅ | ❌ |
-| 🧬 Genetic Strategy Evolution | ✅ | ❌ | ❌ | ❌ | ❌ |
 | 🎮 Process-triggers (auto by .exe) | ✅ | ❌ | ❌ | ❌ | ❌ |
 | ⚙️ Auto-Tune (IPSet × GameFilter) | ✅ | ✅ | ❌ | ❌ | ❌ |
 | 📡 Built-in TG WS Proxy | ✅ | ✅ | ✅ | ❌ | ❌ |


### PR DESCRIPTION
Removed duplicate entries for "Orchestrator (auto-scanning)" and "Genetic Strategy Evolution".