### PR TITLE
docs: add restart suggestion to English Troubleshooting section

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -276,6 +276,8 @@ netstat -ano | findstr :1443
 taskkill /PID <number> /F
 ```
 
+> If that doesn’t help – restart your computer.
+
 ---
 
 ## ⚠️ WinDivert and Antivirus


### PR DESCRIPTION
Add the missing line to the English `README.en.md` – the suggestion to restart the computer if the port 1443 remains busy.

This brings the English version in line with the Russian one after the v1.5.2 release.

Synchronizing `master` with `develop`. No new release required.