### PR TITLE
docs: update interface screenshots in English README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -222,12 +222,12 @@ flowchart LR
 
 <table>
 <tr>
-<td><img src="assets/screenshots/main.png" alt="Main Window" width="400"/></td>
-<td><img src="assets/screenshots/ai.png" alt="AI Orchestrator" width="400"/></td>
+<td><img src="https://github.com/user-attachments/assets/70dda58d-cbf3-43f8-b8ae-72b7fad3d88e" alt="Main Window" width="860"/></td>
+<td><img src="https://github.com/user-attachments/assets/a51c1477-a560-450f-b6ac-ef05ccbec4d2" alt="Update" width="860"/></td>
 </tr>
 <tr>
-<td><img src="assets/screenshots/orchestrator.png" alt="Orchestrator" width="400"/></td>
-<td><img src="assets/screenshots/domains.png" alt="Domain Manager" width="400"/></td>
+<td><img src="https://github.com/user-attachments/assets/bf33cffb-6d56-4055-8f8e-8c807f57d9a7" alt="Orchestrator" width="860"/></td>
+<td><img src="https://github.com/user-attachments/assets/4bdf02a2-83dc-4e39-847a-5c133bfbe6a9" alt="Service" width="860"/></td>
 </tr>
 </table>
 


### PR DESCRIPTION
Replace outdated interface screenshots in `README.en.md` with fresh ones that match the latest UI after the v1.5.2 release.

Synchronizing `master` with `develop`. No new release required.